### PR TITLE
Trio logic & Robot Streak prevention

### DIFF
--- a/src/zm/zm_tomb/Remix2_tomb.gsc
+++ b/src/zm/zm_tomb/Remix2_tomb.gsc
@@ -195,7 +195,7 @@ robot_cycling()
 	level waittill( "giant_robot_intro_complete" );
 	while ( 1 )
 	{
-		if ( level.round_number % 4 && three_robot_round != level.round_number )
+		if ( !(level.round_number % 4) && three_robot_round != level.round_number )
 		{
 			flag_set( "three_robot_round" );
 		}
@@ -252,6 +252,10 @@ robot_cycling()
 			else
 			{
 				random_number = randomint( 3 );
+				while(random_number == last_robot)
+				{
+					random_number = randomint( 3 );
+				}
 			}
 			last_robot = random_number;
 			if( !isDefined( level.first_robot_round ) )


### PR DESCRIPTION
- round_number % 4 is true on rounds not multiple of 4. Needs negation
- Add missing logic to prevent repeat solo robots